### PR TITLE
Instruct linker to search for libdl

### DIFF
--- a/cache/accessor/linux.go
+++ b/cache/accessor/linux.go
@@ -7,6 +7,7 @@
 package accessor
 
 /*
+#cgo LDFLAGS: -ldl
 #include <dlfcn.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
Some build environments need the explicit flag.